### PR TITLE
Add libssl-dev to support mongodb ssl/tls connections.

### DIFF
--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -34,6 +34,7 @@ RUN \
       libicu57 \
       libjpeg-dev \
       libpng-dev \
+      libssl-dev \
       libxml2-dev \
       libzip-dev \
       postgresql-server-dev-9.6 \


### PR DESCRIPTION
* Current MongoDB driver does not support ssl/tls connections. It terminates the connection request with a MongoDB exception: `The "SCRAM-SHA-1" authentication mechanism requires libmongoc built with --enable-ssl`.
  Adding the libssl-dev package allows the mongodb driver build to automatically detect this and enables ssl/tls connections.
