### PR TITLE
Add parameters as proper environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@
 #
 
 sudo: required
-group: deprecated-2017Q3
-language: scala
-scala:
-  - 2.12.7
+dist: xenial
+jdk: openjdk8
+language: java
 services:
   - docker
+
 notifications:
   email: false
   webhooks:

--- a/core/php7.1Action/CHANGELOG.md
+++ b/core/php7.1Action/CHANGELOG.md
@@ -20,6 +20,7 @@
 ## Apache 1.14.0 (next release)
 Changes:
   - Update version of PHP to 7.1.30
+  - Support getenv()
 
 ## Apache 1.13.0-incubating
 Changes:

--- a/core/php7.1Action/router.php
+++ b/core/php7.1Action/router.php
@@ -208,7 +208,6 @@ function run() : array
     if (array_key_exists('value', $post) && is_array($post['value'])) {
         $args = json_encode($post['value']);
     }
-    $env['WHISK_INPUT'] = $args;
 
     // run the action
     list($returnCode, $stdout, $stderr) = runPHP(

--- a/core/php7.1Action/router.php
+++ b/core/php7.1Action/router.php
@@ -199,7 +199,9 @@ function run() : array
     $env['PHP_VERSION'] = $_ENV['PHP_VERSION'];
     foreach (array_keys($post) as $param) {
         if ($param !== "value") {
-            $env['__OW_' . strtoupper($param)] = $post[$param];
+            $envKeyName = '__OW_' . strtoupper($param);
+            $env[$envKeyName] = $post[$param];
+            putenv($envKeyName . '=' . $post[$param]);
         }
     }
 

--- a/core/php7.2Action/CHANGELOG.md
+++ b/core/php7.2Action/CHANGELOG.md
@@ -17,9 +17,10 @@
 #
 -->
 
-## Apache 1.14.0-incubating (next release)
+## Apache 1.14.0 (next release)
 Changes:
   - Update version of PHP to 7.2.19
+  - Support getenv()
 
 ## Apache 1.13.0-incubating
 Changes:

--- a/core/php7.2Action/router.php
+++ b/core/php7.2Action/router.php
@@ -220,7 +220,9 @@ function run() : array
     // assign environment variables from the posted data
     foreach (array_keys($post) as $param) {
         if ($param !== "value") {
-            $_ENV['__OW_' . strtoupper($param)] = $post[$param];
+            $envKeyName = '__OW_' . strtoupper($param);
+            $_ENV[$envKeyName] = $post[$param];
+            putenv($envKeyName . '=' . $post[$param]);
         }
     }
 

--- a/core/php7.2Action/router.php
+++ b/core/php7.2Action/router.php
@@ -229,7 +229,6 @@ function run() : array
     if (array_key_exists('value', $post) && is_array($post['value'])) {
         $args = $post['value'];
     }
-    $_ENV['WHISK_INPUT'] = json_encode($args);
 
     // run the action
     require __DIR__ . '/src/vendor/autoload.php';

--- a/core/php7.3Action/CHANGELOG.md
+++ b/core/php7.3Action/CHANGELOG.md
@@ -20,6 +20,7 @@
 Changes:
   - Update version of PHP to 7.3.6
   - Added PHP extension mongodb
+  - Support getenv()
 
 
 ## Apache 1.13.0-incubating

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -15,14 +15,16 @@
 # limitations under the License.
 #
 
-FROM golang:1.11 as builder
-ENV PROXY_SOURCE=https://github.com/apache/openwhisk-runtime-go/archive/golang1.11@1.13.0-incubating.tar.gz
-RUN curl -L "$PROXY_SOURCE" | tar xzf - \
-  && mkdir -p src/github.com/apache \
-  && mv openwhisk-runtime-go-golang1.11-1.13.0-incubating \
-     src/github.com/apache/incubator-openwhisk-runtime-go \
-  && cd src/github.com/apache/incubator-openwhisk-runtime-go/main \
-  && CGO_ENABLED=0 go build -o /bin/proxy
+FROM golang:1.12 as builder
+RUN env CGO_ENABLED=0 go get github.com/apache/openwhisk-runtime-go/main && mv /go/bin/main /bin/proxy
+#ENV PROXY_SOURCE=https://github.com/apache/openwhisk-runtime-go/archive/golang1.11@1.13.0-incubating.tar.gz
+#RUN curl -L "$PROXY_SOURCE" | tar xzf - \
+#  && mkdir -p src/github.com/apache \
+#  && mv openwhisk-runtime-go-golang1.11-1.13.0-incubating \
+#     src/github.com/apache/incubator-openwhisk-runtime-go \
+#  && cd src/github.com/apache/incubator-openwhisk-runtime-go/main \
+#  && CGO_ENABLED=0 go build -o /bin/proxy
+
 FROM php:7.3.6-cli-stretch
 
 # install dependencies

--- a/core/php7.3Action/runner.php
+++ b/core/php7.3Action/runner.php
@@ -49,10 +49,10 @@ while ($f = fgets(STDIN)) {
 
     // convert all parameters other than value to environment variables
     foreach ($data as $key => $value) {
-        if ($key == 'value') {
-            $_ENV['WHISK_INPUT'] = $data['value'] ?? [];
-        } else {
-            $_ENV['__OW_' . strtoupper($key)] = $value;
+        if ($key !== 'value') {
+            $envKeyName = '__OW_' . strtoupper($key);
+            $_ENV[$envKeyName] = $value;
+            putenv($envKeyName . '=' . $value);
         }
     }
 


### PR DESCRIPTION
The parameters need to be set up as environment variables so that
getenv() can retrieve them too.

Also closes #73.