### PR TITLE
Update PHP & library versions for 7.2 & 7.3

### DIFF
--- a/core/php7.2Action/CHANGELOG.md
+++ b/core/php7.2Action/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ## Apache 1.14.0 (next release)
 Changes:
-  - Update version of PHP to 7.2.19
+  - Update version of PHP to 7.2.25
   - Support getenv()
 
 ## Apache 1.13.0-incubating

--- a/core/php7.2Action/CHANGELOG.md
+++ b/core/php7.2Action/CHANGELOG.md
@@ -20,6 +20,8 @@
 ## Apache 1.14.0 (next release)
 Changes:
   - Update version of PHP to 7.2.25
+  - Update guzzlehttp/guzzle to 6.5.0
+  - Update ramsey/uuid to 3.9.1
   - Support getenv()
 
 ## Apache 1.13.0-incubating

--- a/core/php7.2Action/Dockerfile
+++ b/core/php7.2Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM php:7.2.19-alpine
+FROM php:7.2.25-alpine
 
 RUN \
     apk update && apk upgrade && \

--- a/core/php7.2Action/composer.json
+++ b/core/php7.2Action/composer.json
@@ -5,7 +5,7 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": "6.3.3",
-        "ramsey/uuid": "3.7.3"
+        "guzzlehttp/guzzle": "6.5.0",
+        "ramsey/uuid": "3.9.1"
     }
 }

--- a/core/php7.3Action/CHANGELOG.md
+++ b/core/php7.3Action/CHANGELOG.md
@@ -19,6 +19,8 @@
 ## Apache 1.14.0 (next release)
 Changes:
   - Update version of PHP to 7.3.12
+  - Update guzzlehttp/guzzle to 6.5.0
+  - Update ramsey/uuid to 3.9.1
   - Added PHP extension mongodb
   - Support getenv()
 

--- a/core/php7.3Action/CHANGELOG.md
+++ b/core/php7.3Action/CHANGELOG.md
@@ -18,7 +18,7 @@
 -->
 ## Apache 1.14.0 (next release)
 Changes:
-  - Update version of PHP to 7.3.6
+  - Update version of PHP to 7.3.12
   - Added PHP extension mongodb
   - Support getenv()
 

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -25,7 +25,7 @@ RUN env CGO_ENABLED=0 go get github.com/apache/openwhisk-runtime-go/main && mv /
 #  && cd src/github.com/apache/incubator-openwhisk-runtime-go/main \
 #  && CGO_ENABLED=0 go build -o /bin/proxy
 
-FROM php:7.3.6-cli-stretch
+FROM php:7.3.12-cli-stretch
 
 # install dependencies
 RUN \

--- a/core/php7.3Action/composer.json
+++ b/core/php7.3Action/composer.json
@@ -5,7 +5,7 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": "6.3.3",
-        "ramsey/uuid": "3.8.0"
+        "guzzlehttp/guzzle": "6.5.0",
+        "ramsey/uuid": "3.9.1"
     }
 }


### PR DESCRIPTION
Bring the PHP 7.2 and 7.3 runtimes up to date.

* PHP 7.2.25
* PHP 7.3.12
* guzzlehttp/guzzle to 6.5.0
* ramsey/uuid to 3.9.1  

No B/C breaks.