### PR TITLE
PHP 7.4 runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,11 @@ deploy:
     on:
       branch: master
       repo: apache/openwhisk-runtime-php
+  - provider: script
+    script: "./tools/travis/publish.sh openwhisk 7.4 nightly"
+    on:
+      branch: master
+      repo: apache/openwhisk-runtime-php
 env:
   global:
   - secure: AJZRyRO/ZkStfywAZVN8bk1YmQLHOTD37QdjBsw77CdqnW9Y+a7V3+wZD3W+obQrEhNR9spkKlMh+biE2HFoRwr/AZ3Pl0frzhlyzZXaLUgJMK7wfQzuFVVgjODs4ld2PrJRv5LibFwco9cosDYHe9xlqQ+/Yg/QaWZPK0rBS1UFBxHh1cOcIJ0N80vDXgZbqmH9nuE7W5GvNGzDg9p16w+u48a6UF7UVzf+RU/uR13q7LrAq/FD7dtdiHpamIw4MiGWhW/GZQrwZpzovfGFr365uEVWu+ssQJld+sbeVoN9ED6kOrfYTFg+l7+8cvjhkZ9LUWELK/zVFCu4wYmuhk6utUreBD5rzsfVQmt0Ups7ANIqVS0874CW6WdxO+wPx5Me5k3azXbLgk6mPt4hL0+nlUZ1ycP2rEN/RnL2r8UJAN3vdvL1nXrTTulwNLwS8U3Lc+4yEV+YHQR9c9pYdw3VPx1vNVjEQ34djeoiVxROueBDroZfP3Ft5IazQx4sGPHWfFS1yH5JD58S7YYlz8QEope+Cby1Sj4MUJIjqlT9UgQXq1UydzAWmQPcn81scfITTAWzKHvIXxKrffiVPwkMG67uaUiobd9tDYr+CWpuKXckOSuOi0CwRuGJKyc7lGQvW2zVg7uC56bA9LMD91HYCsRUbNuOox9TXVLjGtM=

--- a/README.md
+++ b/README.md
@@ -24,10 +24,15 @@
 
 ## PHP versions
 
-This runtime provides PHP 7.3 & 7.2.
+This runtime provides PHP 7.4, 7.3 & 7.2.
 
 ### Give it a try today
 To use as a docker action
+
+PHP 7.4:
+```
+wsk action update myAction myAction.php --docker openwhisk/action-php-v7.4:latest
+```
 
 PHP 7.3:
 ```
@@ -44,6 +49,11 @@ This works on any deployment of Apache OpenWhisk
 ### To use on deployment that contains the runtime as a kind
 To use as a kind action
 
+PHP 7.4:
+```
+wsk action update myAction myAction.php --kind php:7.4
+```
+
 PHP 7.3:
 ```
 wsk action update myAction myAction.php --kind php:7.3
@@ -56,19 +66,21 @@ wsk action update myAction myAction.php --kind php:7.2
 
 ### Local development
 ```
+./gradlew core:php7.4Action:distDocker
 ./gradlew core:php7.3Action:distDocker
 ./gradlew core:php7.2Action:distDocker
 ```
-This will produce the images `whisk/action-php-v7.3` & `whisk/action-php-v7.2`
+This will produce the images `whisk/action-php-v7.4`, `whisk/action-php-v7.3` & `whisk/action-php-v7.2` respectively.
 
 Build and Push image
 ```
 docker login
+./gradlew core:php7.4Action:distDocker -PdockerImagePrefix=$prefix-user -PdockerRegistry=docker.io
 ./gradlew core:php7.3Action:distDocker -PdockerImagePrefix=$prefix-user -PdockerRegistry=docker.io
 ./gradlew core:php7.2Action:distDocker -PdockerImagePrefix=$prefix-user -PdockerRegistry=docker.io
 ```
 
-Deploy OpenWhisk using ansible environment that contains the kinds `php:7.3` & `php:7.2`
+Deploy OpenWhisk using ansible environment that contains the kinds `php:7.4`, `php:7.3` & `php:7.2`
 Assuming you have OpenWhisk already deploy locally and `OPENWHISK_HOME` pointing to root directory of OpenWhisk core repository.
 
 Set `ROOTDIR` to the root directory of this repository.
@@ -92,7 +104,11 @@ wskdev fresh -t local-php
 
 To use as docker action push to your own dockerhub account
 ```
-docker tag whisk/php7.2Action $user_prefix/action-php-v7.3
+docker tag whisk/php7.4Action $user_prefix/action-php-v7.4
+docker push $user_prefix/action-php-v7.3
+```
+```
+docker tag whisk/php7.3Action $user_prefix/action-php-v7.3
 docker push $user_prefix/action-php-v7.3
 ```
 ```
@@ -102,7 +118,7 @@ docker push $user_prefix/action-php-v7.2
 
 Then create the action using your the image from dockerhub
 ```
-wsk action update myAction myAction.php --docker $user_prefix/action-php-v7.3
+wsk action update myAction myAction.php --docker $user_prefix/action-php-v7.4
 ```
 The `$user_prefix` is usually your dockerhub user id.
 

--- a/core/php7.4Action/CHANGELOG.md
+++ b/core/php7.4Action/CHANGELOG.md
@@ -1,0 +1,39 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+## Apache 1.14.0 (next release)
+
+Initial release
+
+- Added: PHP: 7.4.0
+- Added: PHP extensions in addition to the standard ones:
+    - bcmath
+    - curl
+    - gd
+    - intl
+    - mbstring
+    - mysqli
+    - pdo_mysql
+    - pdo_pgsql
+    - pdo_sqlite
+    - soap
+    - zip
+    - mongo
+- Added: Composer packages:
+    - [guzzlehttp/guzzle](https://packagist.org/packages/guzzlehttp/guzzle): 6.5.0
+    - [ramsey/uuid](https://packagist.org/packages/ramsey/uuid): 3.9.1

--- a/core/php7.4Action/Dockerfile
+++ b/core/php7.4Action/Dockerfile
@@ -1,0 +1,81 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM golang:1.12 as builder
+RUN env CGO_ENABLED=0 go get github.com/apache/openwhisk-runtime-go/main && mv /go/bin/main /bin/proxy
+#ENV PROXY_SOURCE=https://github.com/apache/openwhisk-runtime-go/archive/golang1.11@1.13.0-incubating.tar.gz
+#RUN curl -L "$PROXY_SOURCE" | tar xzf - \
+#  && mkdir -p src/github.com/apache \
+#  && mv openwhisk-runtime-go-golang1.11-1.13.0-incubating \
+#     src/github.com/apache/incubator-openwhisk-runtime-go \
+#  && cd src/github.com/apache/incubator-openwhisk-runtime-go/main \
+#  && CGO_ENABLED=0 go build -o /bin/proxy
+
+FROM php:7.4.0-cli-buster
+
+# install dependencies
+RUN \
+    apt-get -y update && \
+    apt-get -y install \
+      libfreetype6-dev \
+      libicu-dev \
+      libicu63 \
+      libjpeg-dev \
+      libpng-dev \
+      libssl-dev \
+      libxml2-dev \
+      libzip-dev \
+      postgresql-server-dev-11 \
+      unzip \
+      zlib1g-dev
+
+# Install useful PHP extensions
+RUN \
+    docker-php-ext-install \
+      bcmath \
+      gd \
+      intl \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      soap \
+      zip \
+      && pecl install mongodb \
+      && docker-php-ext-enable mongodb
+
+COPY php.ini /usr/local/etc/php
+
+# install composer
+RUN curl -s -f -L -o /tmp/installer.php https://getcomposer.org/installer \
+    && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer \
+    && composer --ansi --version --no-interaction --no-plugins --no-scripts
+
+# install default Composer dependencies
+RUN mkdir -p /phpAction/composer
+COPY composer.json /phpAction/composer
+RUN cd /phpAction/composer && /usr/bin/composer install --no-plugins --no-scripts --prefer-dist --no-dev -o && rm composer.lock
+
+# install proxy binary alogn with compile and launcher scripts
+RUN mkdir -p /phpAction/action
+WORKDIR /phpAction
+COPY --from=builder /bin/proxy /bin/proxy
+ADD compile /bin/compile
+ADD runner.php /bin/runner.php
+ENV OW_COMPILER=/bin/compile
+
+ENTRYPOINT [ "/bin/proxy" ]

--- a/core/php7.4Action/build.gradle
+++ b/core/php7.4Action/build.gradle
@@ -15,24 +15,5 @@
  * limitations under the License.
  */
 
-include 'tests'
-
-include 'core:php7.2Action'
-include 'core:php7.3Action'
-include 'core:php7.4Action'
-
-rootProject.name = 'runtime-php'
-
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
-
-gradle.ext.scala = [
-    version: '2.12.7',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
+ext.dockerImageName = 'action-php-v7.4'
+apply from: '../../gradle/docker.gradle'

--- a/core/php7.4Action/compile
+++ b/core/php7.4Action/compile
@@ -1,0 +1,82 @@
+#!/usr/bin/env php
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * compile
+ *
+ * This file is launched by the action proxy.
+ * It copies runner.php to right source directory and creates a bash exec script
+ * that the action proxy will call to start everything off
+ */
+
+main($argc, $argv);
+exit;
+
+function main($argc, $argv)
+{
+    if ($argc < 4) {
+        print("usage: <main-function-name> <source-dir> <bin-dir>");
+        exit(1);
+    }
+    $main = $argv[1];
+    $src = realpath($argv[2]);
+    $bin = realpath($argv[3]);
+
+    $shim = $bin.'/exec';
+
+    sources($src);
+    build($shim, $src, $main);
+}
+
+/**
+ * Sort out the source code
+ *
+ * 1. Copy src/exec to src/index.php if necessary
+ * 2. Ensure vendor directory exists
+ */
+function sources(string $src)
+{
+    // If the file uploaded by the user is a plain PHP file, then
+    // the filename will be called exec by the action proxy.
+    // Rename it to index.php
+    if (file_exists($src . '/exec')) {
+        rename($src . '/exec', $src . '/index.php');
+    }
+
+    // put vendor in the right place if it doesn't exist
+    if (!is_dir($src . '/vendor')) {
+        exec('cp -a /phpAction/composer/vendor ' . escapeshellarg($src . '/vendor'));
+    }
+}
+
+/**
+ * Create bin/exec shim
+ */
+function build(string $shim, string $src, string $main) : void
+{
+    $contents = <<<EOT
+#!/bin/bash
+cd $src
+exec php -f /bin/runner.php -- "$main"
+
+EOT;
+
+    file_put_contents($shim, $contents);
+    chmod($shim, 0755);
+}

--- a/core/php7.4Action/composer.json
+++ b/core/php7.4Action/composer.json
@@ -1,0 +1,11 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.3"
+        }
+    },
+    "require": {
+        "guzzlehttp/guzzle": "6.5.0",
+        "ramsey/uuid": "3.9.1"
+    }
+}

--- a/core/php7.4Action/php.ini
+++ b/core/php7.4Action/php.ini
@@ -1,0 +1,37 @@
+; Licensed to the Apache Software Foundation (ASF) under one or more
+; contributor license agreements.  See the NOTICE file distributed with
+; this work for additional information regarding copyright ownership.
+; The ASF licenses this file to You under the Apache License, Version 2.0
+; (the "License"); you may not use this file except in compliance with
+; the License.  You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+[PHP]
+short_open_tag = Off
+output_buffering = Off
+expose_php = Off
+max_execution_time = 0
+memory_limit = -1
+error_reporting = E_ALL
+display_errors = Off
+log_errors = On
+log_errors_max_len = 0
+html_errors = Off
+variables_order = "EGPCS"
+request_order = "GP"
+post_max_size = 0
+enable_dl = Off
+zend.assertions = -1
+
+[opcache]
+opcache.enable=1
+opcache.enable_cli=1
+opcache.max_accelerated_files=7963
+opcache.validate_timestamps=0

--- a/core/php7.4Action/runner.php
+++ b/core/php7.4Action/runner.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * PHP Action runner
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// open fd/3 as that's where we send the result
+$fd3 = fopen('php://fd/3', 'wb');
+
+// Register a shutdown function so that we can fail gracefully when a fatal error occurs
+register_shutdown_function(static function () use ($fd3) {
+    $error = error_get_last();
+    if ($error && in_array($error['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR], true)) {
+        file_put_contents('php://stderr', "An error occurred running the action.\n");
+        fwrite($fd3, "An error occurred running the action.\n");
+    }
+    fclose($fd3);
+});
+
+require 'vendor/autoload.php';
+require 'index.php';
+
+// retrieve main function
+$__functionName = $argv[1] ?? 'main';
+
+
+// read stdin
+while ($f = fgets(STDIN)) {
+    // call the function
+    $data = json_decode($f ?? '', true);
+    if (!is_array($data)) {
+        $data = [];
+    }
+
+    // convert all parameters other than value to environment variables
+    foreach ($data as $key => $value) {
+        if ($key !== 'value') {
+            $envKeyName = '__OW_' . strtoupper($key);
+            $_ENV[$envKeyName] = $value;
+            putenv($envKeyName . '=' . $value);
+        }
+    }
+
+    $values = $data['value'] ?? [];
+    try {
+        $result = $__functionName($values);
+
+        // convert result to an array if we can
+        if (is_object($result)) {
+            if (method_exists($result, 'getArrayCopy')) {
+                $result = $result->getArrayCopy();
+            } elseif ($result instanceof stdClass) {
+                $result = (array)$result;
+            }
+        } elseif ($result === null) {
+            $result = [];
+        }
+
+        // process the result
+        if (!is_array($result)) {
+            file_put_contents('php://stderr', 'Result must be an array but has type "'
+                . gettype($result) . '": ' . $result);
+            file_put_contents('php://stdout', 'The action did not return a dictionary.');
+            $result = (string)$result;
+        } else {
+            $result = json_encode((object)$result);
+        }
+    } catch (Throwable $e) {
+        file_put_contents('php://stderr', (string)$e);
+        $result = 'An error occurred running the action.';
+    }
+
+    // ensure that the sentinels will be on their own lines
+    file_put_contents('php://stderr', "\n");
+    file_put_contents('php://stdout', "\n");
+
+    // cast result to an object for json_encode to ensure that an empty array becomes "{}" & send to fd/3
+    fwrite($fd3, $result . "\n");
+}

--- a/tests/src/test/scala/runtime/actionContainers/Php74ActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/Php74ActionContainerTests.scala
@@ -15,24 +15,13 @@
  * limitations under the License.
  */
 
-include 'tests'
+package runtime.actionContainers
 
-include 'core:php7.2Action'
-include 'core:php7.3Action'
-include 'core:php7.4Action'
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 
-rootProject.name = 'runtime-php'
+@RunWith(classOf[JUnitRunner])
+class Php74ActionContainerTests extends Php7ActionContainerTests {
 
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
-
-gradle.ext.scala = [
-    version: '2.12.7',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
+  override lazy val phpContainerImageName = "action-php-v7.4"
+}


### PR DESCRIPTION
Add a runtime for PHP 7.4. 

No logic, PHP extension or composer package changes from the 7.3 runtime.

Note that this PR builds on #77.