### PR TITLE
Update php docker images to pick up security fixes

### DIFF
--- a/core/php7.2Action/Dockerfile
+++ b/core/php7.2Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM php:7.2.25-alpine
+FROM php:7.2.26-alpine
 
 RUN \
     apk update && apk upgrade && \

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -25,7 +25,7 @@ RUN env CGO_ENABLED=0 go get github.com/apache/openwhisk-runtime-go/main && mv /
 #  && cd src/github.com/apache/incubator-openwhisk-runtime-go/main \
 #  && CGO_ENABLED=0 go build -o /bin/proxy
 
-FROM php:7.3.12-cli-stretch
+FROM php:7.3.13-cli-stretch
 
 # install dependencies
 RUN \

--- a/core/php7.4Action/Dockerfile
+++ b/core/php7.4Action/Dockerfile
@@ -25,7 +25,7 @@ RUN env CGO_ENABLED=0 go get github.com/apache/openwhisk-runtime-go/main && mv /
 #  && cd src/github.com/apache/incubator-openwhisk-runtime-go/main \
 #  && CGO_ENABLED=0 go build -o /bin/proxy
 
-FROM php:7.4.0-cli-buster
+FROM php:7.4.1-cli-buster
 
 # install dependencies
 RUN \


### PR DESCRIPTION
This PR updates the PHP runtime docker images to pick up the latest security fixes.