### PR TITLE
Consume more PHP security updates

### DIFF
--- a/core/php7.2Action/Dockerfile
+++ b/core/php7.2Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM php:7.2.26-alpine
+FROM php:7.2.27-alpine
 
 RUN \
     apk update && apk upgrade && \

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.3.13-cli-stretch
+FROM php:7.3.14-cli-stretch
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release

--- a/core/php7.4Action/Dockerfile
+++ b/core/php7.4Action/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.4.1-cli-buster
+FROM php:7.4.2-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release


### PR DESCRIPTION
Update PHP runtimes to 
* 7.2.27
* 7.3.14
* 7.4.2
to consume security updates
