### PR TITLE
Updgrade PHP base images to gather security fixes

### DIFF
--- a/core/php7.2Action/Dockerfile
+++ b/core/php7.2Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM php:7.2.30-alpine
+FROM php:7.2.31-alpine
 
 RUN \
     apk update && apk upgrade && \

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.3.17-cli-stretch
+FROM php:7.3.18-cli-stretch
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release

--- a/core/php7.4Action/Dockerfile
+++ b/core/php7.4Action/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.4.5-cli-buster
+FROM php:7.4.6-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release

--- a/core/php7.4Action/Dockerfile
+++ b/core/php7.4Action/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.4.6-cli-buster
+FROM php:7.4.5-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release


### PR DESCRIPTION
Upgrade PHP runtimes to
~~7.4.6~~ (reverted due to [PHP Bug 79600](https://bugs.php.net/bug.php?id=79600))
7.3.18
7.2.31