### PR TITLE
Install latest security fixes with every build.

### DIFF
--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -35,8 +35,10 @@ ARG GO_PROXY_BUILD_FROM=release
 
 # install dependencies
 RUN \
-    apt-get -y update && \
-    apt-get -y install \
+    apt-get -y update \
+    # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+    && apt-get upgrade -y --no-install-recommends \
+    && apt-get -y install \
       libfreetype6-dev \
       libicu-dev \
       libicu57 \
@@ -47,7 +49,9 @@ RUN \
       libzip-dev \
       postgresql-server-dev-9.6 \
       unzip \
-      zlib1g-dev
+      zlib1g-dev \
+    # Cleanup apt data, we do not need them later on.
+    && rm -rf /var/lib/apt/lists/*
 
 # Install useful PHP extensions
 RUN \

--- a/core/php7.4Action/Dockerfile
+++ b/core/php7.4Action/Dockerfile
@@ -35,8 +35,10 @@ ARG GO_PROXY_BUILD_FROM=release
 
 # install dependencies
 RUN \
-    apt-get -y update && \
-    apt-get -y install \
+    apt-get -y update \
+    # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+    && apt-get upgrade -y --no-install-recommends \
+    && apt-get -y install \
       libfreetype6-dev \
       libicu-dev \
       libicu63 \
@@ -47,7 +49,9 @@ RUN \
       libzip-dev \
       postgresql-server-dev-11 \
       unzip \
-      zlib1g-dev
+      zlib1g-dev \
+    # Cleanup apt data, we do not need them later on.
+    && rm -rf /var/lib/apt/lists/*
 
 # Install useful PHP extensions
 RUN \


### PR DESCRIPTION
  * Add `apt-get upgrade` to php7.3 and php7.4 to always install latest security fixes during every build.
    This is done to always have an up to date image even when the base image is not updated on a regulare basis.
    The php7.2 runtime already does an `apk upgrade` to install the latest security fixes during every build.
  * Cleanup apt data once they are not required anymore.