### PR TITLE
Update dependencies, CHANGELOG and NOTICE for 1.16.0

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache OpenWhisk Runtime PHP
-Copyright 2016-2020 The Apache Software Foundation
+Copyright 2016-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/core/php7.3Action/CHANGELOG.md
+++ b/core/php7.3Action/CHANGELOG.md
@@ -16,8 +16,11 @@
 # limitations under the License.
 #
 -->
-## Next Release
-  - Update version of PHP to 7.3.23
+## Apache 1.16.0
+  - Update version of PHP to 7.3.27
+  - Use openwhisk-runtime-go 1.17.0 to build proxy
+  - Update guzzlehttp/guzzle to 6.5.5
+  - Update ramsey/uuid to 3.9.3
 
 ## Apache 1.15.0
   - Update version of PHP to 7.3.22

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.3.23-cli-stretch
+FROM php:7.3.27-cli-stretch
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release

--- a/core/php7.3Action/composer.json
+++ b/core/php7.3Action/composer.json
@@ -5,7 +5,7 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": "6.5.0",
-        "ramsey/uuid": "3.9.1"
+        "guzzlehttp/guzzle": "6.5.5",
+        "ramsey/uuid": "3.9.3"
     }
 }

--- a/core/php7.4Action/CHANGELOG.md
+++ b/core/php7.4Action/CHANGELOG.md
@@ -16,8 +16,11 @@
 # limitations under the License.
 #
 -->
-## Next Release
-  - Update version of PHP to 7.4.11
+## Apache 1.16.0
+  - Update version of PHP to 7.4.15
+  - Use openwhisk-runtime-go 1.17.0 to build proxy
+  - Update guzzlehttp/guzzle to 6.5.5
+  - Update ramsey/uuid to 3.9.3
 
 ## Apache 1.15.0
   - Update version of PHP to 7.4.10

--- a/core/php7.4Action/Dockerfile
+++ b/core/php7.4Action/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.4.11-cli-buster
+FROM php:7.4.15-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release

--- a/core/php7.4Action/composer.json
+++ b/core/php7.4Action/composer.json
@@ -5,7 +5,7 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": "6.5.0",
-        "ramsey/uuid": "3.9.1"
+        "guzzlehttp/guzzle": "6.5.5",
+        "ramsey/uuid": "3.9.3"
     }
 }

--- a/core/php8.0Action/CHANGELOG.md
+++ b/core/php8.0Action/CHANGELOG.md
@@ -16,9 +16,11 @@
 # limitations under the License.
 #
 -->
-## Next Release
+## Apache 1.16.0
 Initial release
-- Added: PHP: 8.0.1
+
+- Added: PHP: 8.0.2
+- Used openwhisk-runtime-go 1.17.0 to build proxy
 - Added: PHP extensions in addition to the standard ones:
     - bcmath
     - curl

--- a/core/php8.0Action/Dockerfile
+++ b/core/php8.0Action/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:8.0.1-cli-buster
+FROM php:8.0.2-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release


### PR DESCRIPTION
In preparation for 1.16.0, I've updated to use the latest PHP versions along with the latest versions of our composer dependencies.

Also updated the CHANGELOG for 1.6.0 and the NOTICE to 2021.