### PR TITLE
 Resolve akka versions explicitly.

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -42,10 +42,7 @@ dependencies {
     implementation group: 'com.typesafe.akka', name: "akka-discovery_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
     implementation group: 'com.typesafe.akka', name: "akka-protobuf_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
     implementation group: 'com.typesafe.akka', name: "akka-remote_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
-    implementation group: 'com.typesafe.akka', name: "akka-cluster-metrics_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
     implementation group: 'com.typesafe.akka', name: "akka-cluster_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
-    implementation group: 'com.typesafe.akka', name: "akka-cluster-tools_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
-    implementation group: 'com.typesafe.akka', name: "akka-distributed-data_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
 }
 
 tasks.withType(ScalaCompile) {


### PR DESCRIPTION
- An akka upgrade in apache/openwhisk required changes here to successfully build and run the test cases.
- fix fix taken from [openwhisk-runtime-docker 89](https://github.com/apache/openwhisk-runtime-docker/pull/89)