### PR TITLE
Update PHP releases to gather fixes

### DIFF
--- a/core/php7.3Action/CHANGELOG.md
+++ b/core/php7.3Action/CHANGELOG.md
@@ -17,6 +17,9 @@
 #
 -->
 
+## Next Release
+  - Update version of PHP to 7.3.32
+
 ## Apache 1.17.0
   - Update version of PHP to 7.3.29
   - Build actionloop from 1.16@1.18.0 (#107)

--- a/core/php7.3Action/CHANGELOG.md
+++ b/core/php7.3Action/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ## Next Release
   - Update version of PHP to 7.3.32
+  - Update to Debian "buster"
 
 ## Apache 1.17.0
   - Update version of PHP to 7.3.29

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -52,7 +52,7 @@ RUN \
       libssl-dev \
       libxml2-dev \
       libzip-dev \
-      ppostgresql-server-dev-11 \
+      postgresql-server-dev-11 \
       unzip \
       zlib1g-dev \
     # Cleanup apt data, we do not need them later on.

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.3.29-cli-stretch
+FROM php:7.3.32-cli-stretch
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -46,13 +46,13 @@ RUN \
     && apt-get -y install \
       libfreetype6-dev \
       libicu-dev \
-      libicu57 \
+      libicu63 \
       libjpeg-dev \
       libpng-dev \
       libssl-dev \
       libxml2-dev \
       libzip-dev \
-      postgresql-server-dev-9.6 \
+      ppostgresql-server-dev-11 \
       unzip \
       zlib1g-dev \
     # Cleanup apt data, we do not need them later on.

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.3.32-cli-stretch
+FROM php:7.3.32-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release

--- a/core/php7.4Action/CHANGELOG.md
+++ b/core/php7.4Action/CHANGELOG.md
@@ -17,6 +17,9 @@
 #
 -->
 
+## Next Release
+  - Update version of PHP to 7.4.25
+
 ## Apache 1.17.0
   - Update version of PHP to 7.4.21
   - Build actionloop from 1.16@1.18.0 (#107)

--- a/core/php7.4Action/Dockerfile
+++ b/core/php7.4Action/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.4.21-cli-buster
+FROM php:7.4.25-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release

--- a/core/php8.0Action/CHANGELOG.md
+++ b/core/php8.0Action/CHANGELOG.md
@@ -17,6 +17,9 @@
 #
 -->
 
+## Next Release
+- Update version of PHP to 8.0.11
+
 ## Apache 1.17.0
   - Update version of PHP to 8.0.8
   - Build actionloop from 1.16@1.18.0 (#107)

--- a/core/php8.0Action/Dockerfile
+++ b/core/php8.0Action/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:8.0.8-cli-buster
+FROM php:8.0.11-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release


### PR DESCRIPTION
Update to 8.0.11, 7.4.25 and 7.3.32

Since there is no 7.3 image that is based on Debian "stretch" anymore (7.3.29 was the last one) , 
the base image for 7.3 is changed to Debian "buster"
