### PR TITLE
Update PHP version to 7.4.26

### DIFF
--- a/core/php7.3Action/CHANGELOG.md
+++ b/core/php7.3Action/CHANGELOG.md
@@ -18,7 +18,7 @@
 -->
 
 ## Next Release
-  - Update version of PHP to 7.3.32
+  - Update version of PHP to 7.3.33
   - Update to Debian "buster"
 
 ## Apache 1.17.0

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.3.32-cli-buster
+FROM php:7.3.33-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release

--- a/core/php7.4Action/CHANGELOG.md
+++ b/core/php7.4Action/CHANGELOG.md
@@ -18,7 +18,7 @@
 -->
 
 ## Next Release
-  - Update version of PHP to 7.4.25
+  - Update version of PHP to 7.4.62
 
 ## Apache 1.17.0
   - Update version of PHP to 7.4.21

--- a/core/php7.4Action/Dockerfile
+++ b/core/php7.4Action/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.4.25-cli-buster
+FROM php:7.4.26-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release

--- a/core/php8.0Action/CHANGELOG.md
+++ b/core/php8.0Action/CHANGELOG.md
@@ -18,7 +18,7 @@
 -->
 
 ## Next Release
-- Update version of PHP to 8.0.11
+- Update version of PHP to 8.0.13
 
 ## Apache 1.17.0
   - Update version of PHP to 8.0.8

--- a/core/php8.0Action/Dockerfile
+++ b/core/php8.0Action/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:8.0.11-cli-buster
+FROM php:8.0.13-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release


### PR DESCRIPTION
Update PHP:7.4 version from 7.4.25-cli-buster to 7.4.26-cli-buster
to provide security fix for certain XML parsing functions