### PR TITLE
Update PHP 7.4 and 8.0 images

### DIFF
--- a/core/php7.4Action/CHANGELOG.md
+++ b/core/php7.4Action/CHANGELOG.md
@@ -18,7 +18,7 @@
 -->
 
 ## Next Release
-  - Update version of PHP to 7.4.62
+  - Use php:7.4-cli-buster image to always pull latest patch version
 
 ## Apache 1.17.0
   - Update version of PHP to 7.4.21

--- a/core/php7.4Action/Dockerfile
+++ b/core/php7.4Action/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:7.4.26-cli-buster
+FROM php:7.4-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release

--- a/core/php8.0Action/CHANGELOG.md
+++ b/core/php8.0Action/CHANGELOG.md
@@ -18,7 +18,7 @@
 -->
 
 ## Next Release
-- Update version of PHP to 8.0.13
+  - Use php:8.0-cli-buster image to always pull latest patch version
 
 ## Apache 1.17.0
   - Update version of PHP to 8.0.8

--- a/core/php8.0Action/Dockerfile
+++ b/core/php8.0Action/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:8.0.13-cli-buster
+FROM php:8.0-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release


### PR DESCRIPTION
so the latest patch version is always pulled and the latest security fixes are pulled