### PR TITLE
Install Zip

### DIFF
--- a/core/php7.4Action/Dockerfile
+++ b/core/php7.4Action/Dockerfile
@@ -53,6 +53,7 @@ RUN \
       libxml2-dev \
       libzip-dev \
       postgresql-server-dev-11 \
+      zip \
       unzip \
       zlib1g-dev \
     # Cleanup apt data, we do not need them later on.

--- a/core/php8.0Action/Dockerfile
+++ b/core/php8.0Action/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get -y update \
       libxml2 \
       libzip4 \
       libpq5 \
-      \
+      zip \
       libfreetype6-dev \
       libicu-dev \
       libjpeg-dev \


### PR DESCRIPTION
This is for convenience so customers can package their actions inside of the runtime.