### PR TITLE
Always install latest security fixes (8.0,8.1).

### DIFF
--- a/core/php8.0Action/Dockerfile
+++ b/core/php8.0Action/Dockerfile
@@ -40,6 +40,8 @@ ARG GO_PROXY_BUILD_FROM=release
 
 # install PHP extensions
 RUN apt-get -y update \
+    # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+    && apt-get upgrade -y --no-install-recommends \
     && apt-get -y install --no-install-recommends \
       unzip \
       libfreetype6 \

--- a/core/php8.1Action/Dockerfile
+++ b/core/php8.1Action/Dockerfile
@@ -40,6 +40,8 @@ ARG GO_PROXY_BUILD_FROM=release
 
 # install PHP extensions
 RUN apt-get -y update \
+    # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+    && apt-get upgrade -y --no-install-recommends \
     && apt-get -y install --no-install-recommends \
       unzip \
       libfreetype6 \


### PR DESCRIPTION
- Add 'apt-get upgrade' to always update the already installed packages with the latest security fixes in case they are not already part of the parent image. Sometimes the updates on the parent image take some time and with this explicit upgrade, we are on the save side.